### PR TITLE
Document bot builder flow design in repo agent spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# Repository Agent Instructions
+
+이 리포지터리의 모든 변경 사항은 다음 지침을 따른다.
+
+1. **문서 중심:** README 및 추가 문서는 한국어를 기본으로 작성하되, 코드 스니펫과 API 이름은 원문(영문)을 유지한다.
+2. **구조 준수:** `README.md`에 기재된 디렉터리 구조와 모듈 역할을 변경할 경우, 변경 이유와 새로운 구조를 README에 명확히 반영한다.
+3. **정책 강조:** 알림 접근 권한, 포그라운드 서비스, 접근성 서비스 등 정책/권한 관련 항목을 수정할 때는 관련 근거(공식 문서 링크 등)를 업데이트한다.
+4. **테스트 기록:** 자동 응답 로직이나 큐/레이트 리미터 관련 변경 시에는 테스트 섹션에 해당 시나리오를 추가하고 결과를 명시한다.
+5. **PR 요약:** Pull Request 설명에는 주요 목표(루트 불필요, 규칙 매칭, Reply PendingIntent 재사용)를 항상 포함한다.
+
+---
+
+# 치무봇 메이커(ChimuBot Maker) — 봇 제작 방식 설계 문서
+
+## 1. 개요
+치무봇 메이커는 **Node-RED 스타일의 비주얼 플로우 편집기**와 **메신저봇 R 호환 JS 런타임**을 결합한 하이브리드 자동응답 봇 제작 플랫폼이다.  
+사용자는 GUI에서 트리거-조건-액션 노드를 시각적으로 연결하여 규칙을 구성하며, 내부 엔진은 이를 JSON 플로우 DSL로 직렬화하여 실행 그래프로 변환한다.
+
+---
+
+## 2. 핵심 구성
+### 2.1 플로우 구조
+```
+[Trigger: MessageReceived]
+      ↓
+[Condition: RegexMatch]
+      ↓
+[Script Node (JS Block)]
+      ↓
+[Action: Reply]
+      ↓
+[Action: Webhook]
+```
+
+### 2.2 계층별 역할
+| 계층 | 역할 | 관련 모듈 |
+|------|------|-----------|
+| **GUI (FlowCanvas)** | 노드 생성·연결·편집, 속성 패널 및 코드 에디터 제공 | `features/scripts` (Flow Builder UI) |
+| **RuleEngine** | JSON 플로우 DSL 파싱 → 실행 그래프 구성 | `core/rules` |
+| **Execution Runtime** | 노드 타입별 핸들러 실행, JS 샌드박스 실행 포함 | `core/rules`, `core/dispatch`, `core/state` |
+| **Compat Layer** | 메신저봇 R 스크립트 API (`response()`, `replier.reply()` 등) 호환 | `core/rules/compat` |
+| **Storage** | 룰 및 플로우 데이터 저장 (Room 또는 DataStore) | `data/store`, `data/prefs` |
+
+---
+
+## 3. 하이브리드 모델
+각 노드에는 옵션으로 **JS Script Block**을 내장할 수 있다.  
+사용자가 GUI 노드 속성에서 직접 코드를 작성하면 엔진은 이를 QuickJS 샌드박스에서 실행한다.
+
+예시 코드:
+```
+if (msg.includes("주문")) {
+  replier.reply("주문 확인했습니다 😎");
+  webhook("https://api/order", {room, msg});
+}
+```
+
+→ Node-RED의 Function 노드 + 메신저봇 R의 스크립트 함수를 통합한 형태.
+
+---
+
+## 4. 메신저봇 R 호환성
+- 기존 메신저봇 R 스크립트(`response(room, msg, sender, isGroupChat, replier, ...)`)를 그대로 실행 가능.  
+- **ChimuCompatLayer.kt**에서 다음 API를 바인딩:
+  - `replier.reply(text)` → `core/dispatch/ReplySender.send()`로 위임  
+  - `Api`, `Log`, `FileStream`, `Utils` 등 Stub 구현  
+- GUI에서 `.js` 스크립트를 직접 불러와 Script Node로 삽입 가능.
+
+---
+
+## 5. JSON 플로우 DSL 예시
+```
+{
+  "nodes": [
+    {"id":"n1","type":"trigger.message","params":{"app":"com.kakao.talk"}},
+    {"id":"n2","type":"condition.regex","params":{"pattern":".*주문.*"}},
+    {"id":"n3","type":"script.js","params":{"code":"replier.reply('주문완료');"}},
+    {"id":"n4","type":"action.reply","params":{"text":"감사합니다!"}}
+  ],
+  "edges": [
+    {"from":"n1","to":"n2"},
+    {"from":"n2","to":"n3"},
+    {"from":"n3","to":"n4"}
+  ]
+}
+```
+
+`RuleEngine.buildFrom(json)` → ExecutionGraph 생성 → 각 노드 핸들러 실행.
+
+---
+
+## 6. 런타임 상호작용
+- **JS 엔진:** QuickJS (경량 임베디드 JS)  
+- **Sandbox:** 전역 객체 격리(`room`, `msg`, `replier` 등 바인딩)  
+- **Replier Bridge:** 메신저봇 API → Notification Reply 액션 직접 연결  
+- **Context Storage:** 노드 간 변수 공유(`context.set/get`) 지원 (`core/state` 연동)  
+
+---
+
+## 7. GUI 모듈 설계
+| 모듈 | 설명 | 배치 |
+|------|------|------|
+| **FlowCanvas** | 노드 드래그·연결, 연결선 렌더링 (Compose Canvas or ReactFlow) | `features/scripts/flowbuilder` |
+| **NodePropertyPanel** | 노드별 파라미터 편집 (정규식, 메시지 등) | `features/scripts/flowbuilder` |
+| **ScriptEditorDialog** | Script Node 용 코드 에디터 (Monaco / CodeMirror) | `features/scripts/editor` |
+| **SimulationPanel** | 입력 이벤트 테스트 + 로그 출력 | `features/diagnostics`와 연계 |
+| **FlowManager** | JSON 로드/세이브/내보내기 | `data/store` ↔ `features/scripts` |
+| **RuntimeConnector** | RuleEngine와 실시간 상태 동기화 | `core/rules` ↔ `features/scripts` |
+
+---
+
+## 8. 기술 스택
+| 영역 | 기술 |
+|------|------|
+| **언어/플랫폼** | Kotlin + Jetpack Compose |
+| **Persistence** | Room 또는 Proto DataStore |
+| **JS Runtime** | QuickJS 또는 Rhino (개발 단계에서 선택) |
+| **네트워킹** | OkHttp / Retrofit |
+| **로깅** | Timber + 내장 LogView |
+| **멀티모듈** | `core/`(notif, rules, dispatch, state), `data/`(store, telemetry, prefs), `features/`(scripts, sharing, diagnostics), `runtime/compat`(메신저봇 API 브리지) |
+
+---
+
+## 9. 개발 단계 권장 순서
+1. **Core 엔진 프로토타입** – NotificationListener + ReplySender + RuleEngine (`core/notif`, `core/rules`, `core/dispatch`).
+2. **플로우 DSL → 실행 그래프** 변환기 구현 (`core/rules`와 `data/store`).
+3. **QuickJS 통합 및 Compat Layer** 완성 (`runtime/compat`, `core/rules/compat`).
+4. **Node-RED 형식 GUI (FlowCanvas + Property Panel)** – `features/scripts/flowbuilder`.
+5. **시뮬레이터 및 런타임 연동 테스트** – `features/diagnostics` + `core/rules`.
+6. **규칙 패키지 배포/공유 기능** 추가 – `features/scripts` + `data/store`.
+
+---
+
+## 10. 요약 비전
+> **ChimuBot Maker = Node-RED + 메신저봇 R + Notification Automation**  
+> GUI로 규칙을 만들고, JS 로직을 혼합하며, 메신저봇 R 스크립트까지 실행하는 루트리스 자동응답 플랫폼.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,122 @@
-# ChimuBot-Maker
+# ChimuBot Maker
+
+ChimuBot Maker는 Android NotificationListenerService 기반의 자동 응답 엔진을 구현하기 위한 설계 문서와 레퍼런스 구조를 정리한 리포지터리입니다. 루트 권한 없이 알림을 수신하고, 규칙 기반으로 자동 답장을 전송하며, 동일 알림의 Reply `PendingIntent`를 재사용하여 여러 차례 응답할 수 있도록 하는 것을 목표로 합니다.
+
+## 주요 목표
+- **루트 불필요:** 시스템 권한 없이 사용자 허용을 통한 알림 접근.
+- **알림 → 규칙 → 답장 파이프라인:** 수신된 알림을 파싱하여 규칙에 매칭하고 자동 응답을 전송.
+- **Reply `PendingIntent` 재사용:** 동일 알림이 살아있는 동안 여러 번 자동 응답.
+- **선택 기능:** 응답 결과 추적, 전송 큐/속도 제어, 간단한 텔레메트리.
+
+## 비스코프
+- 다른 앱 DB 직접 접근, 숨겨진 Binder 호출, 패치/리패키징, 내부 API 리플렉션 등 비공식 경로는 사용하지 않습니다.
+- 미디어를 완전 무인으로 전송하지 않으며, 필요 시 공유 Intent와 접근성 보조를 결합합니다.
+
+## 시스템 구성
+대화 상태 추적과 텔레메트리 요구가 늘어남에 따라 `core` 모듈을 세분화하고, 영속 계층(`data/`)과 진단 기능(`features/diagnostics`)을 명시적으로 분리했습니다. 아래 구조는 알림 파이프라인과 운영 도구의 책임을 명확히 합니다.
+```
+app/
+ ├─ core/
+ │   ├─ notif/              # 알림 파싱·Reply 핸들 추출
+ │   ├─ rules/              # 규칙 DSL, 매칭 엔진, 샌드박스 실행
+ │   ├─ dispatch/           # SendQueue, RateLimiter, Retry 정책
+ │   ├─ state/              # 알림/대화 캐시, TTL 관리
+ │   └─ sys/                # NotificationListenerService, ForegroundSvc
+ ├─ data/
+ │   ├─ store/              # Room/ProtoDatastore, DAO, 마이그레이션
+ │   ├─ telemetry/          # 전송 로그, 실패 통계 수집
+ │   └─ prefs/              # 사용자 설정, 기능 토글
+ ├─ features/
+ │   ├─ scripts/            # 규칙 작성 UI, 스크립트 배포
+ │   ├─ sharing/            # 공유 Intent + 접근성 보조
+ │   └─ diagnostics/        # 알림 흐름 모니터링, 재연도구
+ └─ ui/
+     ├─ onboarding/         # 권한 온보딩, 배터리 최적화 안내
+     ├─ settings/           # 전역 설정, 규칙 관리 접근
+     └─ rules/              # 규칙 편집/테스트 화면
+```
+
+## 핵심 동작 요약
+1. **알림 수신:** `NotificationListenerService`로 알림/제거/랭킹 변동 콜백 처리.
+2. **Reply 액션 추출:** `Notification.Action` 중 `RemoteInput`이 있는 Reply 액션을 찾음.
+3. **자동 전송:** `RemoteInput.addResultsToIntent()` 후 `PendingIntent.send()`로 반복 응답.
+4. **규칙 매칭:** `RuleEngine`이 조건을 평가하여 `SendQueue`에 메시지를 enqueue.
+5. **전송 제어:** `RateLimiter`와 재시도 정책으로 안정성 확보.
+
+## 권한 및 정책
+- `BIND_NOTIFICATION_LISTENER_SERVICE`: 서비스 선언 후 사용자 설정에서 허용 유도.
+- Android 13+: 자체 알림 표시 시 `POST_NOTIFICATIONS` 런타임 권한 요청.
+- (선택) 포그라운드 서비스 사용 시 Android 14+에서 타입 선언 및 정책 준수.
+- 배터리 최적화 예외는 필요한 경우에만 사용자 동의를 받고 요청.
+
+## 구현 체크리스트
+- 매니페스트에 알림 리스너 서비스 선언 및 온보딩 화면 제공.
+- 알림 extras(`EXTRA_TITLE`, `EXTRA_TEXT` 등) 파싱과 Reply 핸들 캐싱.
+- `PendingIntent.CanceledException` 처리 및 알림 재동기화 로직 구현.
+- 잠금화면, Doze/App Standby, 제조사별 백그라운드 제약 대응.
+- 프라이버시 및 Play 정책 준수: 접근성 서비스 사용 시 고지/동의 필수.
+
+## 테스트 시나리오
+- Reply 액션 탐지 및 반복 전송 검증.
+- 알림 교체/종료 시 핸들 갱신.
+- 잠금 상태 전송 및 재시도.
+- Doze/배터리 최적화 환경에서 지연/안정성 확인.
+- 제조사별 커스텀 OS에서 서비스 유지 여부 확인.
+
+## 기능 로드맵
+알림 파이프라인을 기반으로 실제 메신저 자동 응답 봇을 완성하기 위해 다음 단계별 기능을 계획합니다. 각 항목은 `core/`, `data/`, `features/`, `ui/` 모듈의 책임 분리에 맞춰 진행하며, 선행 조건과 산출물을 명확히 정의합니다.
+
+### 1단계: 카카오톡 알림 파싱 기반 구축
+- **목표:** 카카오톡의 채팅 알림 구조를 안정적으로 해석하여 `CapturedNotification` 모델에 담습니다.
+- **주요 작업:**
+  - `core/notif/NotificationParser` 확장: MessagingStyle 기반 메시지 배열, `EXTRA_CONVERSATION_TITLE`에서 room id 후보 추출.
+  - `data/store`에 카카오톡 전용 파싱 결과 스키마 추가(방 식별자, 마지막 발신자, 멀티 라인 메시지 등).
+  - Diagnostics 모듈에 원시 알림 JSON 덤프 뷰 제공(개발 모드 한정, 개인정보 마스킹).
+- **선행 조건:** 알림 접근 권한 확보 UX 완료, 기본 Reply 액션 추출 기능 동작.
+- **완료 기준:** 실제 카카오톡 알림 수신 시 룸 정보·메시지 본문·Reply 핸들이 로그/데이터 스토어에서 확인 가능.
+
+### 2단계: Reply 전송 루틴 고도화
+- **목표:** 카카오톡 Reply PendingIntent를 재사용해 다중 자동 응답을 안정적으로 전송합니다.
+- **주요 작업:**
+  - `core/dispatch/ReplySender`에 카카오톡 특화 예외 처리(알림 교체, CanceledException 백오프) 추가.
+  - `core/state`에서 알림 수명/룸별 Reply 핸들 캐시 TTL 관리.
+  - Telemetry에 전송 성공/실패 카운터 및 재시도 이력 기록.
+- **선행 조건:** 카카오톡 알림 파싱이 룸 식별까지 지원.
+- **완료 기준:** 동일 알림으로 3회 이상 자동 답장 테스트를 통과하고, 실패 시 재시도 로직이 동작.
+
+### 3단계: 테스트 알림 생성기
+- **목표:** 카카오톡 알림을 모방한 테스트 알림을 생성해 파서/전송 파이프라인을 앱 내에서 재현합니다.
+- **주요 작업:**
+  - `features/diagnostics`에 테스트 알림 생성 Activity 추가, MessagingStyle 구성 요소 선택 UI 제공.
+  - `ui/onboarding` 또는 개발자 설정에 테스트 알림 트리거 버튼 배치.
+  - 생성된 알림이 실제 카카오톡 알림과 동일한 extras/pendingIntent 인터페이스를 가지도록 시나리오 스크립트 정의.
+- **선행 조건:** Reply 전송 루틴이 안정화되어 실제 알림에서 검증 완료.
+- **완료 기준:** 테스트 알림으로 파서→규칙→전송 전체 플로우를 로컬에서 검증 가능, 실 단말 연결 없이 회귀 테스트 수행.
+
+### 4단계: 봇 작동 관리 UI
+- **목표:** 봇을 전체 On/Off 하거나 특정 방(room id) 단위로 제어할 수 있는 관리 기능을 제공합니다.
+- **주요 작업:**
+  - `ui/settings`에 글로벌 토글과 룸 리스트 관리 화면 추가, `data/prefs`에 상태 저장.
+  - `core/state`에서 최근 대화 목록을 유지하고, 룸별 마지막 메시지 미리보기를 제공.
+  - `features/scripts`의 RuleEngine 진입점에서 룸 필터(허용/차단 목록) 적용.
+- **선행 조건:** 룸 id 추출 및 최근 대화 캐시가 작동.
+- **완료 기준:** 사용자가 UI에서 룸을 선택해 봇 활성화 여부를 변경하면 즉시 규칙 평가에 반영.
+
+### 5단계: 봇 제작 기능(초기 버전)
+- **목표:** 사용자가 규칙 기반 봇을 생성/편집할 수 있는 제작 도구의 1차 버전을 제공합니다.
+- **주요 작업(초안):**
+  - 규칙 템플릿 갤러리와 간단한 스크립트 편집기(`features/scripts`) 구현.
+  - `RuleEngine`이 사용자 정의 파라미터(키워드, 응답 텍스트, 시간 제한 등)를 수용하도록 DSL 확장.
+  - 제작한 봇의 동작을 시뮬레이션하는 미리보기(테스트 알림과 연동) 제공.
+- **선행 조건:** 테스트 알림 생성기와 룸 기반 봇 제어가 안정화.
+- **완료 기준:** 최소 1개 이상의 커스텀 봇을 생성해 특정 룸에 배포하고, 자동 응답 결과를 텔레메트리에서 확인 가능.
+
+### 장기 과제
+- 전송 큐 레이트 리미터 자동 튜닝(트래픽 기반 동적 조절).
+- 텔레메트리 시각화 대시보드 및 로그 내보내기.
+- 접근성 보조를 통한 미디어 공유 워크플로(정책 검토 후).
+
+## 추가 자료
+- Android Developers: NotificationListenerService, RemoteInput, PendingIntent.
+- Microsoft Learn: `ACTION_NOTIFICATION_LISTENER_SETTINGS` 진입.
+- Google Play 정책: 접근성 서비스, 포그라운드 서비스 신고 요건.


### PR DESCRIPTION
## Summary
- embed the Node-RED style flow builder design guidance into AGENTS.md so future updates stay aligned with the rootless notification listener, rule-based automation, and Reply PendingIntent reuse pipeline

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3067546588322b6ebd4fa02137630