### PR TITLE
Add notification log UI for parsed KakaoTalk notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Gradle
+.gradle/
+build/
+**/build/
+gradle/wrapper/*.jar
+
+# Android Studio
+.idea/
+*.iml
+
+# Misc
+local.properties
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# Repository Agent Instructions
+
+이 리포지터리의 모든 변경 사항은 다음 지침을 따른다.
+
+1. **문서 중심:** README 및 추가 문서는 한국어를 기본으로 작성하되, 코드 스니펫과 API 이름은 원문(영문)을 유지한다.
+2. **구조 준수:** `README.md`에 기재된 디렉터리 구조와 모듈 역할을 변경할 경우, 변경 이유와 새로운 구조를 README에 명확히 반영한다.
+3. **정책 강조:** 알림 접근 권한, 포그라운드 서비스, 접근성 서비스 등 정책/권한 관련 항목을 수정할 때는 관련 근거(공식 문서 링크 등)를 업데이트한다.
+4. **테스트 기록:** 자동 응답 로직이나 큐/레이트 리미터 관련 변경 시에는 테스트 섹션에 해당 시나리오를 추가하고 결과를 명시한다.
+5. **PR 요약:** Pull Request 설명에는 주요 목표(루트 불필요, 규칙 매칭, Reply PendingIntent 재사용)를 항상 포함한다.
+
+---
+
+# 치무봇 메이커(ChimuBot Maker) — 봇 제작 방식 설계 문서
+
+## 1. 개요
+치무봇 메이커는 **Node-RED 스타일의 비주얼 플로우 편집기**와 **메신저봇 R 호환 JS 런타임**을 결합한 하이브리드 자동응답 봇 제작 플랫폼이다.  
+사용자는 GUI에서 트리거-조건-액션 노드를 시각적으로 연결하여 규칙을 구성하며, 내부 엔진은 이를 JSON 플로우 DSL로 직렬화하여 실행 그래프로 변환한다.
+
+---
+
+## 2. 핵심 구성
+### 2.1 플로우 구조
+```
+[Trigger: MessageReceived]
+      ↓
+[Condition: RegexMatch]
+      ↓
+[Script Node (JS Block)]
+      ↓
+[Action: Reply]
+      ↓
+[Action: Webhook]
+```
+
+### 2.2 계층별 역할
+| 계층 | 역할 | 관련 모듈 |
+|------|------|-----------|
+| **GUI (FlowCanvas)** | 노드 생성·연결·편집, 속성 패널 및 코드 에디터 제공 | `features/scripts` (Flow Builder UI) |
+| **RuleEngine** | JSON 플로우 DSL 파싱 → 실행 그래프 구성 | `core/rules` |
+| **Execution Runtime** | 노드 타입별 핸들러 실행, JS 샌드박스 실행 포함 | `core/rules`, `core/dispatch`, `core/state` |
+| **Compat Layer** | 메신저봇 R 스크립트 API (`response()`, `replier.reply()` 등) 호환 | `core/rules/compat` |
+| **Storage** | 룰 및 플로우 데이터 저장 (Room 또는 DataStore) | `data/store`, `data/prefs` |
+
+---
+
+## 3. 하이브리드 모델
+각 노드에는 옵션으로 **JS Script Block**을 내장할 수 있다.
+사용자가 GUI 노드 속성에서 직접 코드를 작성하면 엔진은 이를 QuickJS 샌드박스에서 실행한다.
+QuickJS 런타임은 메신저봇 R API2 사양에서 정의한 전역 객체(`Api`, `Log`, `Utils`, `FileStream` 등)를 동일한 시그니처로 바인딩해야 하며, 레퍼런스는 Dark Tornado와 KBOT Docs의 API2 문서를 기준으로 관리한다.
+
+예시 코드:
+```
+if (msg.includes("주문")) {
+  replier.reply("주문 확인했습니다 😎");
+  webhook("https://api/order", {room, msg});
+}
+```
+
+→ Node-RED의 Function 노드 + 메신저봇 R의 스크립트 함수를 통합한 형태.
+
+---
+
+## 4. 메신저봇 R 호환성
+- 기존 메신저봇 R 스크립트(`response(room, msg, sender, isGroupChat, replier, ...)`)를 그대로 실행 가능.
+- **ChimuCompatLayer.kt**에서 다음 API를 바인딩:
+  - `replier.reply(text)` → `core/dispatch/ReplySender.send()`로 위임
+  - `Api`, `Log`, `FileStream`, `Utils`, `Device`, `Utils.getRoomList()` 등 API2에서 필수로 요구하는 객체/메서드를 Stub 또는 실제 동작과 연결
+- GUI에서 `.js` 스크립트를 직접 불러와 Script Node로 삽입 가능하며, 노드 속성 패널에서 API2 함수 호출을 템플릿으로 제안한다.
+- API2에서 새롭게 추가된 이벤트(`onCreate`, `onCommand`, `onNotificationPosted` 등)가 필요할 경우 FlowCanvas 노드 타입으로 선행 정의하고, Execution Runtime에서 해당 이벤트를 트리거로 매핑한다.
+
+---
+
+## 5. JSON 플로우 DSL 예시
+```
+{
+  "nodes": [
+    {"id":"n1","type":"trigger.message","params":{"app":"com.kakao.talk"}},
+    {"id":"n2","type":"condition.regex","params":{"pattern":".*주문.*"}},
+    {"id":"n3","type":"script.js","params":{"code":"replier.reply('주문완료');"}},
+    {"id":"n4","type":"action.reply","params":{"text":"감사합니다!"}}
+  ],
+  "edges": [
+    {"from":"n1","to":"n2"},
+    {"from":"n2","to":"n3"},
+    {"from":"n3","to":"n4"}
+  ]
+}
+```
+
+`RuleEngine.buildFrom(json)` → ExecutionGraph 생성 → 각 노드 핸들러 실행.
+
+---
+
+## 6. 런타임 상호작용
+- **JS 엔진:** QuickJS (경량 임베디드 JS)  
+- **Sandbox:** 전역 객체 격리(`room`, `msg`, `replier` 등 바인딩)  
+- **Replier Bridge:** 메신저봇 API → Notification Reply 액션 직접 연결  
+- **Context Storage:** 노드 간 변수 공유(`context.set/get`) 지원 (`core/state` 연동)  
+
+---
+
+## 7. GUI 모듈 설계
+| 모듈 | 설명 | 배치 |
+|------|------|------|
+| **FlowCanvas** | 노드 드래그·연결, 연결선 렌더링 (Compose Canvas or ReactFlow) | `features/scripts/flowbuilder` |
+| **NodePropertyPanel** | 노드별 파라미터 편집 (정규식, 메시지 등) | `features/scripts/flowbuilder` |
+| **ScriptEditorDialog** | Script Node 용 코드 에디터 (Monaco / CodeMirror), API2 함수 인텔리센스/자동완성 제공 | `features/scripts/editor` |
+| **SimulationPanel** | 입력 이벤트 테스트 + 로그 출력 | `features/diagnostics`와 연계 |
+| **FlowManager** | JSON 로드/세이브/내보내기 | `data/store` ↔ `features/scripts` |
+| **RuntimeConnector** | RuleEngine와 실시간 상태 동기화 | `core/rules` ↔ `features/scripts` |
+
+---
+
+## 8. 기술 스택
+| 영역 | 기술 |
+|------|------|
+| **언어/플랫폼** | Kotlin + Jetpack Compose |
+| **Persistence** | Room 또는 Proto DataStore |
+| **JS Runtime** | QuickJS 또는 Rhino (개발 단계에서 선택), API2 표준 전역 객체 바인딩 |
+| **네트워킹** | OkHttp / Retrofit |
+| **로깅** | Timber + 내장 LogView |
+| **멀티모듈** | `core/`(notif, rules, dispatch, state), `data/`(store, telemetry, prefs), `features/`(scripts, sharing, diagnostics), `runtime/compat`(메신저봇 API 브리지) |
+
+---
+
+## 9. 개발 단계 권장 순서
+1. **Core 엔진 프로토타입** – NotificationListener + ReplySender + RuleEngine (`core/notif`, `core/rules`, `core/dispatch`).
+2. **플로우 DSL → 실행 그래프** 변환기 구현 (`core/rules`와 `data/store`).
+3. **QuickJS 통합 및 Compat Layer** 완성 (`runtime/compat`, `core/rules/compat`).
+4. **Node-RED 형식 GUI (FlowCanvas + Property Panel)** – `features/scripts/flowbuilder`.
+5. **시뮬레이터 및 런타임 연동 테스트** – `features/diagnostics` + `core/rules`.
+6. **규칙 패키지 배포/공유 기능** 추가 – `features/scripts` + `data/store`.
+
+---
+
+## 10. 요약 비전
+> **ChimuBot Maker = Node-RED + 메신저봇 R + Notification Automation**
+> GUI로 규칙을 만들고, JS 로직을 혼합하며, 메신저봇 R 스크립트까지 실행하는 루트리스 자동응답 플랫폼.
+
+---
+
+## 11. 1단계 코드 구현 지침
+- `core/notif`은 **KakaoTalk 알림 전용 필터**를 기본값으로 유지한다. 다른 메신저를 다룰 때는 새로운 `NotificationTargetFilter`를 추가하고 레지스트리에 명시적으로 교체한다.
+- `core/dispatch`의 `ReplyDispatcher`는 코루틴 기반 싱글 컨슈머를 유지하며, rate-limit 상수는 80~200ms 범위 내에서만 수정한다. 재시도 정책을 확장할 때는 `RuleEngine`에 실패 신호를 전달할 수 있는 콜백을 추가한다.
+- `core/rules`는 `RuleEngineRegistry`를 통해 전역 인스턴스를 노출한다. NotificationListener에서 직접 구현 클래스를 참조하지 말고, 레지스트리에 주입하도록 유지한다.
+- Kotlin JVM 타겟은 17로 고정하며, 새로운 모듈을 추가할 때 동일한 `compileOptions`/`kotlinOptions` 설정을 복제한다.
+- 테스트나 샘플 코드를 위해 `SimpleLoggingRuleEngine`을 수정할 경우, README의 “1단계 프로토타입 구현 현황”을 갱신해 동작이 어떻게 바뀌었는지 기록한다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,9 @@ if (msg.includes("주문")) {
 - `core/rules`는 `RuleEngineRegistry`를 통해 전역 인스턴스를 노출한다. NotificationListener에서 직접 구현 클래스를 참조하지 말고, 레지스트리에 주입하도록 유지한다.
 - Kotlin JVM 타겟은 17로 고정하며, 새로운 모듈을 추가할 때 동일한 `compileOptions`/`kotlinOptions` 설정을 복제한다.
 - 테스트나 샘플 코드를 위해 `SimpleLoggingRuleEngine`을 수정할 경우, README의 “1단계 프로토타입 구현 현황”을 갱신해 동작이 어떻게 바뀌었는지 기록한다.
+
+## 12. 2단계 Reply 전송 고도화 지침
+- `core/state/ReplyHandleCache`는 Reply `PendingIntent`의 TTL을 `SystemClock.elapsedRealtime()` 기준으로 관리한다. 알림이 교체되거나 제거되면 반드시 `invalidate(key)`를 호출하고, UI와 동기화되는 `metrics` 흐름을 최신 상태로 유지한다.
+- `core/state/ReplySendTelemetry`는 `ReplySendObserver` 인터페이스를 구현해 성공/실패/재시도 이벤트를 `StateFlow`로 노출한다. UI는 이 흐름을 직접 구독하므로 필드를 제거하거나 이름을 바꿀 때는 README와 레이아웃 문서를 동시에 수정한다.
+- `ReplyDispatcher`는 `ReplyHandleProvider`를 통해 핸들을 조회하고, 실패 시 `handleProvider.invalidate()`로 캐시를 무효화한다. 백오프는 300ms부터 시작해 두 배씩 증가하되 1.2s를 상한으로 유지한다.
+- UI 모듈(`NotificationLogActivity`)은 Stage 2 Telemetry를 시각화해야 하므로, 전송 관련 변경 시 상단 카드가 새로운 메트릭을 반영하도록 업데이트한다.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,130 @@
-# ChimuBot-Maker
+# ChimuBot Maker
+
+ChimuBot Maker는 Android NotificationListenerService 기반의 자동 응답 엔진을 구현하기 위한 설계 문서와 레퍼런스 구조를 정리한 리포지터리입니다. 루트 권한 없이 알림을 수신하고, 규칙 기반으로 자동 답장을 전송하며, 동일 알림의 Reply `PendingIntent`를 재사용하여 여러 차례 응답할 수 있도록 하는 것을 목표로 합니다.
+
+## 주요 목표
+- **루트 불필요:** 시스템 권한 없이 사용자 허용을 통한 알림 접근.
+- **알림 → 규칙 → 답장 파이프라인:** 수신된 알림을 파싱하여 규칙에 매칭하고 자동 응답을 전송.
+- **Reply `PendingIntent` 재사용:** 동일 알림이 살아있는 동안 여러 번 자동 응답.
+- **선택 기능:** 응답 결과 추적, 전송 큐/속도 제어, 간단한 텔레메트리.
+
+## 비스코프
+- 다른 앱 DB 직접 접근, 숨겨진 Binder 호출, 패치/리패키징, 내부 API 리플렉션 등 비공식 경로는 사용하지 않습니다.
+- 미디어를 완전 무인으로 전송하지 않으며, 필요 시 공유 Intent와 접근성 보조를 결합합니다.
+
+## 시스템 구성
+Gradle 멀티모듈 프로젝트로 1단계 프로토타입을 구성했습니다. `core` 하위 모듈은 알림 파이프라인의 핵심 요소를 담당하고, `app` 모듈은 NotificationListenerService 선언과 함께 **최근 파싱된 알림을 확인할 수 있는 경량 UI(Activity)**를 제공합니다. 추후 `data/`, `features/`, `ui/` 모듈은 추가될 예정입니다.
+```
+ChimuBot-Maker/
+ ├─ app/                    # AndroidManifest, 서비스 선언, 알림 파서 로그 Activity
+ ├─ core/
+ │   ├─ notif/              # NotificationListenerService, Kakao 알림 파싱
+ │   ├─ dispatch/           # Reply PendingIntent 큐잉, 레이트 리미터
+ │   └─ rules/              # 규칙 인터페이스, 샘플 RuleEngine 구현
+ ├─ data/                   # (추가 예정) Room/ProtoDatastore 계층
+ ├─ features/               # (추가 예정) FlowCanvas, Diagnostics 등
+ └─ ui/                     # (추가 예정) 온보딩, 설정, 룰 편집 화면
+```
+
+## 핵심 동작 요약
+1. **알림 수신:** `NotificationListenerService`로 알림/제거/랭킹 변동 콜백 처리.
+2. **Reply 액션 추출:** `Notification.Action` 중 `RemoteInput`이 있는 Reply 액션을 찾음.
+3. **자동 전송:** `RemoteInput.addResultsToIntent()` 후 `PendingIntent.send()`로 반복 응답.
+4. **규칙 매칭:** `RuleEngine`이 조건을 평가하여 `SendQueue`에 메시지를 enqueue.
+5. **전송 제어:** `RateLimiter`와 재시도 정책으로 안정성 확보.
+
+## 권한 및 정책
+- `BIND_NOTIFICATION_LISTENER_SERVICE`: 서비스 선언 후 사용자 설정에서 허용 유도.
+- Android 13+: 자체 알림 표시 시 `POST_NOTIFICATIONS` 런타임 권한 요청.
+- (선택) 포그라운드 서비스 사용 시 Android 14+에서 타입 선언 및 정책 준수.
+- 배터리 최적화 예외는 필요한 경우에만 사용자 동의를 받고 요청.
+
+## 구현 체크리스트
+- 매니페스트에 알림 리스너 서비스 선언 및 온보딩 화면 제공.
+- 알림 extras(`EXTRA_TITLE`, `EXTRA_TEXT` 등) 파싱과 Reply 핸들 캐싱.
+- `PendingIntent.CanceledException` 처리 및 알림 재동기화 로직 구현.
+- 잠금화면, Doze/App Standby, 제조사별 백그라운드 제약 대응.
+- 프라이버시 및 Play 정책 준수: 접근성 서비스 사용 시 고지/동의 필수.
+
+## 테스트 시나리오
+- Reply 액션 탐지 및 반복 전송 검증.
+- 알림 교체/종료 시 핸들 갱신.
+- 잠금 상태 전송 및 재시도.
+- Doze/배터리 최적화 환경에서 지연/안정성 확인.
+- 제조사별 커스텀 OS에서 서비스 유지 여부 확인.
+
+## 기능 로드맵
+알림 파이프라인을 기반으로 실제 메신저 자동 응답 봇을 완성하기 위해 다음 단계별 기능을 계획합니다. 각 항목은 `core/`, `data/`, `features/`, `ui/` 모듈의 책임 분리에 맞춰 진행하며, 선행 조건과 산출물을 명확히 정의합니다.
+
+### 1단계 프로토타입 구현 현황
+- **알림 로그 UI:** `NotificationLogActivity`가 카카오톡 알림이 파싱될 때마다 룸/보낸이/본문/타임스탬프를 실시간 리스트로 표시합니다. NotificationListenerService와 동일 프로세스에서 `NotificationLogRepository`의 `StateFlow`를 구독해 본문과 파싱 결과를 시각적으로 검증할 수 있습니다.
+- **NotificationListenerService 배치:** `core/notif/ChimuNotificationListener`를 앱 매니페스트에 등록하고, 서비스 생성 시 `RuleEngine`과 `ReplyDispatcher`를 초기화합니다.
+- **카카오톡 전용 필터:** `NotificationTargetRegistry`에 `KakaoTalkOnlyFilter`를 설치해 `com.kakao.talk` 알림만 처리합니다.
+- **알림 파싱 모델:** `NotificationParser`가 MessagingStyle 메시지 배열에서 최신 본문과 발신자를 추출해 `CapturedNotification` 데이터 클래스로 매핑합니다.
+- **Reply 큐 프로토타입:** `core/dispatch/ReplyDispatcher`가 코루틴 채널을 사용해 Reply PendingIntent 전송을 직렬화하고, `ReplySender`가 RemoteInput에 텍스트를 주입합니다.
+- **샘플 RuleEngine:** `SimpleLoggingRuleEngine`이 “자동응답” 키워드를 감지하면 테스트용 응답 메시지를 큐에 넣습니다.
+
+### 1단계: 카카오톡 알림 파싱 기반 구축
+- **목표:** 카카오톡의 채팅 알림 구조를 안정적으로 해석하여 `CapturedNotification` 모델에 담습니다.
+- **주요 작업:**
+  - `core/notif/NotificationParser` 확장: MessagingStyle 기반 메시지 배열, `EXTRA_CONVERSATION_TITLE`에서 room id 후보 추출.
+  - `data/store`에 카카오톡 전용 파싱 결과 스키마 추가(방 식별자, 마지막 발신자, 멀티 라인 메시지 등).
+  - Diagnostics 모듈에 원시 알림 JSON 덤프 뷰 제공(개발 모드 한정, 개인정보 마스킹).
+- **선행 조건:** 알림 접근 권한 확보 UX 완료, 기본 Reply 액션 추출 기능 동작.
+- **완료 기준:** 실제 카카오톡 알림 수신 시 룸 정보·메시지 본문·Reply 핸들이 로그/데이터 스토어에서 확인 가능.
+
+### 2단계: Reply 전송 루틴 고도화
+- **목표:** 카카오톡 Reply PendingIntent를 재사용해 다중 자동 응답을 안정적으로 전송합니다.
+- **주요 작업:**
+  - `core/dispatch/ReplySender`에 카카오톡 특화 예외 처리(알림 교체, CanceledException 백오프) 추가.
+  - `core/state`에서 알림 수명/룸별 Reply 핸들 캐시 TTL 관리.
+  - Telemetry에 전송 성공/실패 카운터 및 재시도 이력 기록.
+- **선행 조건:** 카카오톡 알림 파싱이 룸 식별까지 지원.
+- **완료 기준:** 동일 알림으로 3회 이상 자동 답장 테스트를 통과하고, 실패 시 재시도 로직이 동작.
+
+### 3단계: 테스트 알림 생성기
+- **목표:** 카카오톡 알림을 모방한 테스트 알림을 생성해 파서/전송 파이프라인을 앱 내에서 재현합니다.
+- **주요 작업:**
+  - `features/diagnostics`에 테스트 알림 생성 Activity 추가, MessagingStyle 구성 요소 선택 UI 제공.
+  - `ui/onboarding` 또는 개발자 설정에 테스트 알림 트리거 버튼 배치.
+  - 생성된 알림이 실제 카카오톡 알림과 동일한 extras/pendingIntent 인터페이스를 가지도록 시나리오 스크립트 정의.
+- **선행 조건:** Reply 전송 루틴이 안정화되어 실제 알림에서 검증 완료.
+- **완료 기준:** 테스트 알림으로 파서→규칙→전송 전체 플로우를 로컬에서 검증 가능, 실 단말 연결 없이 회귀 테스트 수행.
+
+### 4단계: 봇 작동 관리 UI
+- **목표:** 봇을 전체 On/Off 하거나 특정 방(room id) 단위로 제어할 수 있는 관리 기능을 제공합니다.
+- **주요 작업:**
+  - `ui/settings`에 글로벌 토글과 룸 리스트 관리 화면 추가, `data/prefs`에 상태 저장.
+  - `core/state`에서 최근 대화 목록을 유지하고, 룸별 마지막 메시지 미리보기를 제공.
+  - `features/scripts`의 RuleEngine 진입점에서 룸 필터(허용/차단 목록) 적용.
+- **선행 조건:** 룸 id 추출 및 최근 대화 캐시가 작동.
+- **완료 기준:** 사용자가 UI에서 룸을 선택해 봇 활성화 여부를 변경하면 즉시 규칙 평가에 반영.
+
+### 5단계: 봇 제작 기능(초기 버전)
+- **목표:** 사용자가 규칙 기반 봇을 생성/편집할 수 있는 제작 도구의 1차 버전을 제공합니다.
+- **주요 작업(초안):**
+  - 규칙 템플릿 갤러리와 간단한 스크립트 편집기(`features/scripts`) 구현.
+  - `RuleEngine`이 사용자 정의 파라미터(키워드, 응답 텍스트, 시간 제한 등)를 수용하도록 DSL 확장.
+  - API2 이벤트/액션 노드(예: `message`, `onCommand`, `Api.replyRoom`)와 매핑되는 노드 팔레트를 정의해 GUI와 JS 런타임이 동일한 계약을 공유하도록 설계.
+  - 제작한 봇의 동작을 시뮬레이션하는 미리보기(테스트 알림과 연동) 제공.
+- **선행 조건:** 테스트 알림 생성기와 룸 기반 봇 제어가 안정화.
+- **완료 기준:** 최소 1개 이상의 커스텀 봇을 생성해 특정 룸에 배포하고, 자동 응답 결과를 텔레메트리에서 확인 가능.
+
+## 메신저봇 R API2 호환성 및 GUI 연계
+- **API2 스펙 준수:** JS 런타임과 Compat Layer는 메신저봇 R API2에서 정의된 전역 함수 및 객체(`response()`, `replier.reply()`, `Api.replyRoom()`, `Utils.getRoomList()` 등)를 동일한 시그니처로 노출하며, Dark Tornado 및 KBOT Docs의 API2 레퍼런스를 기준으로 검증합니다.
+- **노드 팔레트 설계:** FlowCanvas 상의 Trigger/Action 노드는 API2의 이벤트(`response`, `onCreate`, `onCommand`)와 행동(`Api.replyRoom`, `Api.sendImage`, `Api.reload`)을 표현할 수 있도록 타입과 파라미터를 제공합니다. 사용자가 GUI에서 선택한 노드는 실행 그래프 변환 시 API2 호환 JS 코드 스텁으로 직렬화됩니다.
+- **Script Node 가드:** Script Node 내부에서 API2 전역을 활용할 때 QuickJS 샌드박스가 동일한 객체를 바인딩해 개발자가 메신저봇 R 스크립트를 거의 수정 없이 가져올 수 있도록 합니다.
+- **테스트 전략:** 테스트 알림 생성기와 시뮬레이션 패널에서 API2 호출의 Mock 결과(예: `Api.replyRoom` 호출 횟수)를 기록하여 GUI·JS가 동일하게 동작하는지 확인합니다.
+- **문서화:** GUI 도움말과 개발자 문서에 API2 함수별 지원 상태와 예외 사항을 명시해 사용자가 호환 범위를 즉시 이해할 수 있도록 합니다.
+
+### 장기 과제
+- 전송 큐 레이트 리미터 자동 튜닝(트래픽 기반 동적 조절).
+- 텔레메트리 시각화 대시보드 및 로그 내보내기.
+- 접근성 보조를 통한 미디어 공유 워크플로(정책 검토 후).
+
+## 추가 자료
+- Android Developers: NotificationListenerService, RemoteInput, PendingIntent.
+- Microsoft Learn: `ACTION_NOTIFICATION_LISTENER_SETTINGS` 진입.
+- Google Play 정책: 접근성 서비스, 포그라운드 서비스 신고 요건.
+- Dark Tornado: KakaoTalk Bot API2 레퍼런스.
+- KBOT Docs: MessengerBot API2 함수 설명.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chimubot.maker.app"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.chimubot.maker.app"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        debug {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":core:notif"))
+    implementation(project(":core:dispatch"))
+    implementation(project(":core:rules"))
+    implementation("androidx.activity:activity-ktx:1.8.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(project(":core:notif"))
     implementation(project(":core:dispatch"))
     implementation(project(":core:rules"))
+    implementation(project(":core:state"))
     implementation("androidx.activity:activity-ktx:1.8.2")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.recyclerview:recyclerview:1.3.2")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Placeholder for future rules

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chimubot.maker.app">
+
+    <application
+        android:allowBackup="false"
+        android:label="@string/app_name"
+        android:theme="@android:style/Theme.DeviceDefault">
+        <activity
+            android:name="com.chimubot.maker.app.ui.NotificationLogActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name="com.chimubot.maker.core.notif.ChimuNotificationListener"
+            android:label="ChimuBot Notification Listener"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogActivity.kt
+++ b/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogActivity.kt
@@ -1,0 +1,52 @@
+package com.chimubot.maker.app.ui
+
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.chimubot.maker.app.R
+import com.chimubot.maker.core.notif.NotificationLogRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+class NotificationLogActivity : ComponentActivity() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var emptyView: View
+    private lateinit var adapter: NotificationLogAdapter
+    private var collectJob: Job? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_notification_log)
+
+        findViewById<TextView>(R.id.notification_log_toolbar_title).text =
+            getString(R.string.notification_log_title)
+        recyclerView = findViewById(R.id.notification_log_list)
+        emptyView = findViewById(R.id.notification_log_empty)
+        adapter = NotificationLogAdapter()
+
+        recyclerView.layoutManager = LinearLayoutManager(this)
+        recyclerView.adapter = adapter
+    }
+
+    override fun onStart() {
+        super.onStart()
+        collectJob = lifecycleScope.launch {
+            NotificationLogRepository.items.collectLatest { items ->
+                adapter.submitList(items)
+                emptyView.visibility = if (items.isEmpty()) View.VISIBLE else View.GONE
+            }
+        }
+    }
+
+    override fun onStop() {
+        collectJob?.cancel()
+        collectJob = null
+        super.onStop()
+    }
+}

--- a/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogActivity.kt
+++ b/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogActivity.kt
@@ -9,9 +9,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.chimubot.maker.app.R
 import com.chimubot.maker.core.notif.NotificationLogRepository
+import com.chimubot.maker.core.state.ReplyHandleCache
+import com.chimubot.maker.core.state.ReplySendTelemetry
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.text.DateFormat
+import java.util.Date
 
 class NotificationLogActivity : ComponentActivity() {
 
@@ -19,6 +23,14 @@ class NotificationLogActivity : ComponentActivity() {
     private lateinit var emptyView: View
     private lateinit var adapter: NotificationLogAdapter
     private var collectJob: Job? = null
+    private var telemetryJob: Job? = null
+    private var handleMetricsJob: Job? = null
+    private lateinit var successView: TextView
+    private lateinit var failureView: TextView
+    private lateinit var retryView: TextView
+    private lateinit var lastErrorView: TextView
+    private lateinit var handleSummaryView: TextView
+    private val timestampFormatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,6 +41,11 @@ class NotificationLogActivity : ComponentActivity() {
         recyclerView = findViewById(R.id.notification_log_list)
         emptyView = findViewById(R.id.notification_log_empty)
         adapter = NotificationLogAdapter()
+        successView = findViewById(R.id.notification_log_metric_success_value)
+        failureView = findViewById(R.id.notification_log_metric_failure_value)
+        retryView = findViewById(R.id.notification_log_metric_retry_value)
+        lastErrorView = findViewById(R.id.notification_log_metric_last_error)
+        handleSummaryView = findViewById(R.id.notification_log_metric_handle_summary)
 
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = adapter
@@ -42,11 +59,38 @@ class NotificationLogActivity : ComponentActivity() {
                 emptyView.visibility = if (items.isEmpty()) View.VISIBLE else View.GONE
             }
         }
+        telemetryJob = lifecycleScope.launch {
+            ReplySendTelemetry.metrics.collectLatest { metrics ->
+                successView.text = metrics.successCount.toString()
+                failureView.text = metrics.failureCount.toString()
+                retryView.text = metrics.retryCount.toString()
+                val lastError = metrics.lastErrorMessage
+                lastErrorView.text = if (lastError.isNullOrBlank()) {
+                    getString(R.string.notification_log_metric_last_error_none)
+                } else {
+                    getString(R.string.notification_log_metric_last_error, lastError)
+                }
+            }
+        }
+        handleMetricsJob = lifecycleScope.launch {
+            ReplyHandleCache.metrics.collectLatest { metrics ->
+                val formatted = timestampFormatter.format(Date(metrics.lastUpdatedAt))
+                handleSummaryView.text = getString(
+                    R.string.notification_log_metric_handles_template,
+                    metrics.activeCount,
+                    formatted
+                )
+            }
+        }
     }
 
     override fun onStop() {
         collectJob?.cancel()
         collectJob = null
+        telemetryJob?.cancel()
+        telemetryJob = null
+        handleMetricsJob?.cancel()
+        handleMetricsJob = null
         super.onStop()
     }
 }

--- a/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogAdapter.kt
+++ b/app/src/main/java/com/chimubot/maker/app/ui/NotificationLogAdapter.kt
@@ -1,0 +1,61 @@
+package com.chimubot.maker.app.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.chimubot.maker.app.R
+import com.chimubot.maker.core.notif.NotificationLogItem
+import java.text.DateFormat
+import java.util.Date
+
+class NotificationLogAdapter :
+    ListAdapter<NotificationLogItem, NotificationLogAdapter.NotificationLogViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotificationLogViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_notification_log, parent, false)
+        return NotificationLogViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: NotificationLogViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class NotificationLogViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val title: TextView = itemView.findViewById(R.id.notification_log_item_title)
+        private val subtitle: TextView = itemView.findViewById(R.id.notification_log_item_subtitle)
+        private val body: TextView = itemView.findViewById(R.id.notification_log_item_body)
+        private val timestamp: TextView = itemView.findViewById(R.id.notification_log_item_timestamp)
+        private val dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+
+        fun bind(item: NotificationLogItem) {
+            title.text = item.room ?: itemView.context.getString(R.string.notification_log_unknown_room)
+            val senderInfo = if (item.sender.isNullOrBlank()) {
+                itemView.context.getString(R.string.notification_log_unknown_sender)
+            } else {
+                item.sender
+            }
+            subtitle.text = itemView.context.getString(
+                R.string.notification_log_metadata_format,
+                senderInfo,
+                item.packageName
+            )
+            body.text = item.body ?: itemView.context.getString(R.string.notification_log_empty_body)
+            timestamp.text = dateFormat.format(Date(item.postedAt))
+        }
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<NotificationLogItem>() {
+        override fun areItemsTheSame(oldItem: NotificationLogItem, newItem: NotificationLogItem): Boolean {
+            return oldItem.key == newItem.key
+        }
+
+        override fun areContentsTheSame(oldItem: NotificationLogItem, newItem: NotificationLogItem): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_notification_log.xml
+++ b/app/src/main/res/layout/activity_notification_log.xml
@@ -21,6 +21,112 @@
         android:text="@string/notification_log_subtitle"
         android:textAppearance="@android:style/TextAppearance.Material.Body1" />
 
+    <LinearLayout
+        android:id="@+id/notification_log_metrics_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="vertical"
+        android:padding="12dp"
+        android:background="?android:attr/colorBackgroundFloating">
+
+        <TextView
+            android:id="@+id/notification_log_metrics_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/notification_log_metrics_title"
+            android:textAppearance="@android:style/TextAppearance.Material.Medium"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/notification_log_metric_success"
+                    android:textAppearance="@android:style/TextAppearance.Material.Caption" />
+
+                <TextView
+                    android:id="@+id/notification_log_metric_success_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="0"
+                    android:textAppearance="@android:style/TextAppearance.Material.Large"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/notification_log_metric_failure"
+                    android:textAppearance="@android:style/TextAppearance.Material.Caption" />
+
+                <TextView
+                    android:id="@+id/notification_log_metric_failure_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="0"
+                    android:textAppearance="@android:style/TextAppearance.Material.Large"
+                    android:textStyle="bold" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="8dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/notification_log_metric_retry"
+                    android:textAppearance="@android:style/TextAppearance.Material.Caption" />
+
+                <TextView
+                    android:id="@+id/notification_log_metric_retry_value"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="0"
+                    android:textAppearance="@android:style/TextAppearance.Material.Large"
+                    android:textStyle="bold" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/notification_log_metric_last_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/notification_log_metric_last_error_none"
+            android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+
+        <TextView
+            android:id="@+id/notification_log_metric_handle_summary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/notification_log_metric_handles_default"
+            android:textAppearance="@android:style/TextAppearance.Material.Caption" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/notification_log_list"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_notification_log.xml
+++ b/app/src/main/res/layout/activity_notification_log.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/notification_log_toolbar_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Material.Headline"
+        android:textColor="@android:color/black"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/notification_log_toolbar_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="@string/notification_log_subtitle"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/notification_log_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:id="@+id/notification_log_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="24dp"
+        android:text="@string/notification_log_empty"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_notification_log.xml
+++ b/app/src/main/res/layout/item_notification_log.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/notification_log_item_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/notification_log_item_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:textColor="@android:color/darker_gray" />
+
+    <TextView
+        android:id="@+id/notification_log_item_body"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Body1" />
+
+    <TextView
+        android:id="@+id/notification_log_item_timestamp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textAppearance="@android:style/TextAppearance.Material.Small"
+        android:textColor="@android:color/darker_gray" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<resources>
+    <string name="app_name">ChimuBot Maker</string>
+    <string name="notification_log_title">알림 파서 로그</string>
+    <string name="notification_log_subtitle">카카오톡 알림 본문과 파싱 결과를 실시간으로 확인하세요.</string>
+    <string name="notification_log_empty">수신된 카카오톡 알림이 아직 없습니다.</string>
+    <string name="notification_log_unknown_room">알 수 없는 대화방</string>
+    <string name="notification_log_unknown_sender">알 수 없는 보낸이</string>
+    <string name="notification_log_empty_body">본문 없음</string>
+    <string name="notification_log_metadata_format">%1$s · %2$s</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,12 @@
     <string name="notification_log_unknown_sender">알 수 없는 보낸이</string>
     <string name="notification_log_empty_body">본문 없음</string>
     <string name="notification_log_metadata_format">%1$s · %2$s</string>
+    <string name="notification_log_metrics_title">Reply 전송 상태</string>
+    <string name="notification_log_metric_success">성공</string>
+    <string name="notification_log_metric_failure">실패</string>
+    <string name="notification_log_metric_retry">재시도</string>
+    <string name="notification_log_metric_last_error">마지막 오류: %1$s</string>
+    <string name="notification_log_metric_last_error_none">마지막 오류: 없음</string>
+    <string name="notification_log_metric_handles_template">활성 Reply 핸들: %1$d개 · 업데이트 %2$s</string>
+    <string name="notification_log_metric_handles_default">활성 Reply 핸들: 0개 · 업데이트 대기 중</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("com.android.application") version "8.1.2" apply false
+    id("com.android.library") version "8.1.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/core/dispatch/build.gradle.kts
+++ b/core/dispatch/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chimubot.maker.core.dispatch"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+}

--- a/core/dispatch/src/main/AndroidManifest.xml
+++ b/core/dispatch/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chimubot.maker.core.dispatch" />

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyDispatcher.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyDispatcher.kt
@@ -12,37 +12,97 @@ import kotlinx.coroutines.launch
 
 class ReplyDispatcher(
     context: Context,
+    private val handleProvider: ReplyHandleProvider = ReplyHandleProvider.NO_OP,
+    private val observer: ReplySendObserver = ReplySendObserver.NONE,
     private val sendAction: (Context, ReplyHandle, CharSequence) -> Unit = ReplySender::send,
     coroutineScope: CoroutineScope? = null,
-    private val minIntervalMs: Long = 150L
+    private val minIntervalMs: Long = 150L,
+    private val maxAttempts: Int = 4
 ) {
     private val appContext = context.applicationContext
     private val job = SupervisorJob()
     private val scope = coroutineScope ?: CoroutineScope(Dispatchers.IO + job)
-    private val channel = Channel<Pair<OutgoingMessage, ReplyHandle>>(Channel.UNLIMITED)
+    private val channel = Channel<DispatchRequest>(Channel.UNLIMITED)
 
     init {
         scope.launch {
-            for ((message, handle) in channel) {
-                runCatching {
-                    sendAction(appContext, handle, message.text)
-                    delay(minIntervalMs)
-                }.onFailure { error ->
-                    Log.w(TAG, "Reply send failed for ${message.notificationKey}", error)
-                    delay(minIntervalMs)
-                }
+            for (request in channel) {
+                process(request)
             }
         }
     }
 
     fun enqueue(message: OutgoingMessage, handle: ReplyHandle) {
-        channel.trySend(message to handle)
+        channel.trySend(DispatchRequest(message, handle))
     }
 
     fun close() {
         channel.close()
         job.cancel()
     }
+
+    private suspend fun process(request: DispatchRequest) {
+        val message = request.message
+        val handle = handleProvider.currentHandleFor(message.notificationKey, message.room)
+            ?: request.fallbackHandle
+        if (handle == null) {
+            val error = ReplySendException.MissingHandle(message.notificationKey)
+            Log.w(TAG, "No reply handle for ${message.notificationKey}")
+            observer.onFailure(error)
+            scheduleRetryIfPossible(request.copy(fallbackHandle = null))
+            delay(minIntervalMs)
+            return
+        }
+
+        try {
+            sendAction(appContext, handle, message.text)
+            observer.onSuccess()
+        } catch (error: ReplySendException.HandleExpired) {
+            Log.w(TAG, "Reply handle expired for ${message.notificationKey}")
+            observer.onFailure(error)
+            handleProvider.invalidate(message.notificationKey)
+            scheduleRetryIfPossible(request.copy(fallbackHandle = null))
+        } catch (error: ReplySendException.TransportFailed) {
+            Log.w(TAG, "Reply send failed for ${message.notificationKey}", error)
+            observer.onFailure(error)
+            scheduleRetryIfPossible(request.copy(fallbackHandle = null))
+        } catch (error: Exception) {
+            Log.e(TAG, "Unexpected error sending reply for ${message.notificationKey}", error)
+            observer.onFailure(error)
+        }
+
+        delay(minIntervalMs)
+    }
+
+    private suspend fun scheduleRetryIfPossible(request: DispatchRequest) {
+        val currentAttempt = request.message.attempt
+        if (currentAttempt >= maxAttempts) {
+            Log.w(TAG, "Max retry attempts reached for ${request.message.notificationKey}")
+            return
+        }
+        val nextAttempt = currentAttempt + 1
+        observer.onRetryScheduled(nextAttempt)
+        val backoff = computeBackoffDelay(nextAttempt)
+        delay(backoff)
+        channel.trySend(
+            DispatchRequest(
+                message = request.message.copy(attempt = nextAttempt),
+                fallbackHandle = null
+            )
+        )
+    }
+
+    private fun computeBackoffDelay(attempt: Int): Long {
+        val base = 300L
+        val multiplier = 1 shl (attempt - 1)
+        val delay = base * multiplier
+        return delay.coerceAtMost(1_200L)
+    }
+
+    private data class DispatchRequest(
+        val message: OutgoingMessage,
+        val fallbackHandle: ReplyHandle?
+    )
 
     companion object {
         private const val TAG = "ReplyDispatcher"

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyDispatcher.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyDispatcher.kt
@@ -1,0 +1,50 @@
+package com.chimubot.maker.core.dispatch
+
+import android.content.Context
+import android.util.Log
+import com.chimubot.maker.core.rules.OutgoingMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class ReplyDispatcher(
+    context: Context,
+    private val sendAction: (Context, ReplyHandle, CharSequence) -> Unit = ReplySender::send,
+    coroutineScope: CoroutineScope? = null,
+    private val minIntervalMs: Long = 150L
+) {
+    private val appContext = context.applicationContext
+    private val job = SupervisorJob()
+    private val scope = coroutineScope ?: CoroutineScope(Dispatchers.IO + job)
+    private val channel = Channel<Pair<OutgoingMessage, ReplyHandle>>(Channel.UNLIMITED)
+
+    init {
+        scope.launch {
+            for ((message, handle) in channel) {
+                runCatching {
+                    sendAction(appContext, handle, message.text)
+                    delay(minIntervalMs)
+                }.onFailure { error ->
+                    Log.w(TAG, "Reply send failed for ${message.notificationKey}", error)
+                    delay(minIntervalMs)
+                }
+            }
+        }
+    }
+
+    fun enqueue(message: OutgoingMessage, handle: ReplyHandle) {
+        channel.trySend(message to handle)
+    }
+
+    fun close() {
+        channel.close()
+        job.cancel()
+    }
+
+    companion object {
+        private const val TAG = "ReplyDispatcher"
+    }
+}

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyHandle.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyHandle.kt
@@ -1,0 +1,13 @@
+package com.chimubot.maker.core.dispatch
+
+import android.app.PendingIntent
+import androidx.core.app.RemoteInput
+
+/**
+ * Direct Reply PendingIntent 및 RemoteInput 메타데이터.
+ */
+data class ReplyHandle(
+    val pendingIntent: PendingIntent,
+    val remoteInputs: Array<RemoteInput>,
+    val ttlMs: Long
+)

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyHandleProvider.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplyHandleProvider.kt
@@ -1,0 +1,16 @@
+package com.chimubot.maker.core.dispatch
+
+/**
+ * Reply PendingIntent를 조회/무효화하는 계약. core/state 모듈에서 구현한다.
+ */
+interface ReplyHandleProvider {
+    fun currentHandleFor(notificationKey: String, room: String?): ReplyHandle?
+    fun invalidate(notificationKey: String)
+
+    companion object {
+        val NO_OP: ReplyHandleProvider = object : ReplyHandleProvider {
+            override fun currentHandleFor(notificationKey: String, room: String?): ReplyHandle? = null
+            override fun invalidate(notificationKey: String) = Unit
+        }
+    }
+}

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySendException.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySendException.kt
@@ -1,0 +1,13 @@
+package com.chimubot.maker.core.dispatch
+
+import android.app.PendingIntent
+
+sealed class ReplySendException(message: String, cause: Throwable? = null) : Exception(message, cause) {
+    class HandleExpired(cause: PendingIntent.CanceledException) :
+        ReplySendException("Reply handle expired", cause)
+
+    class TransportFailed(cause: Throwable) : ReplySendException("Reply send failed", cause)
+
+    class MissingHandle(notificationKey: String) :
+        ReplySendException("Missing reply handle for $notificationKey")
+}

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySendObserver.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySendObserver.kt
@@ -1,0 +1,18 @@
+package com.chimubot.maker.core.dispatch
+
+/**
+ * Reply 전송 결과/재시도 이벤트를 관찰하기 위한 훅. Telemetry 모듈이 구현한다.
+ */
+interface ReplySendObserver {
+    fun onSuccess()
+    fun onFailure(error: Throwable)
+    fun onRetryScheduled(attempt: Int)
+
+    companion object {
+        val NONE: ReplySendObserver = object : ReplySendObserver {
+            override fun onSuccess() = Unit
+            override fun onFailure(error: Throwable) = Unit
+            override fun onRetryScheduled(attempt: Int) = Unit
+        }
+    }
+}

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySender.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySender.kt
@@ -1,5 +1,6 @@
 package com.chimubot.maker.core.dispatch
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -12,6 +13,12 @@ object ReplySender {
         val primaryKey = handle.remoteInputs.first().resultKey
         results.putCharSequence(primaryKey, text)
         RemoteInput.addResultsToIntent(handle.remoteInputs, fillIn, results)
-        handle.pendingIntent.send(context, 0, fillIn)
+        try {
+            handle.pendingIntent.send(context, 0, fillIn)
+        } catch (error: PendingIntent.CanceledException) {
+            throw ReplySendException.HandleExpired(error)
+        } catch (error: Exception) {
+            throw ReplySendException.TransportFailed(error)
+        }
     }
 }

--- a/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySender.kt
+++ b/core/dispatch/src/main/java/com/chimubot/maker/core/dispatch/ReplySender.kt
@@ -1,0 +1,17 @@
+package com.chimubot.maker.core.dispatch
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.RemoteInput
+
+object ReplySender {
+    fun send(context: Context, handle: ReplyHandle, text: CharSequence) {
+        val fillIn = Intent()
+        val results = Bundle()
+        val primaryKey = handle.remoteInputs.first().resultKey
+        results.putCharSequence(primaryKey, text)
+        RemoteInput.addResultsToIntent(handle.remoteInputs, fillIn, results)
+        handle.pendingIntent.send(context, 0, fillIn)
+    }
+}

--- a/core/notif/build.gradle.kts
+++ b/core/notif/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chimubot.maker.core.notif"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":core:dispatch"))
+    implementation(project(":core:rules"))
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+}

--- a/core/notif/src/main/AndroidManifest.xml
+++ b/core/notif/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chimubot.maker.core.notif">
+
+    <application />
+</manifest>

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/ChimuNotificationListener.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/ChimuNotificationListener.kt
@@ -1,0 +1,37 @@
+package com.chimubot.maker.core.notif
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import com.chimubot.maker.core.rules.RuleEngineRegistry
+
+class ChimuNotificationListener : NotificationListenerService() {
+
+    override fun onCreate() {
+        super.onCreate()
+        NotificationServiceInitializer.ensure(applicationContext)
+        Log.i(TAG, "Notification listener created")
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        if (!NotificationTargetRegistry.current().shouldProcess(sbn.packageName)) {
+            Log.d(TAG, "Package filtered: ${sbn.packageName}")
+            return
+        }
+        val captured = NotificationParser.parse(sbn)
+        if (captured == null) {
+            Log.d(TAG, "Failed to parse notification: ${sbn.key}")
+            return
+        }
+        NotificationLogRepository.record(captured)
+        RuleEngineRegistry.current().onIncoming(captured)
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification) {
+        Log.d(TAG, "Notification removed: ${sbn.key}")
+    }
+
+    companion object {
+        private const val TAG = "ChimuNotifListener"
+    }
+}

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationLogRepository.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationLogRepository.kt
@@ -1,0 +1,45 @@
+package com.chimubot.maker.core.notif
+
+import com.chimubot.maker.core.rules.CapturedNotification
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * 최근에 파싱된 알림을 UI에 노출하기 위한 간단한 인메모리 저장소.
+ */
+object NotificationLogRepository {
+
+    private const val MAX_LOG_SIZE = 50
+
+    private val _items = MutableStateFlow<List<NotificationLogItem>>(emptyList())
+    val items: StateFlow<List<NotificationLogItem>> = _items.asStateFlow()
+
+    fun record(notification: CapturedNotification) {
+        val entry = NotificationLogItem(
+            key = notification.key,
+            packageName = notification.packageName,
+            room = notification.room,
+            sender = notification.sender,
+            body = notification.text,
+            postedAt = notification.postedAt
+        )
+        _items.update { current ->
+            val withoutSameKey = current.filterNot { it.key == entry.key }
+            (listOf(entry) + withoutSameKey).take(MAX_LOG_SIZE)
+        }
+    }
+}
+
+/**
+ * UI가 본문/파싱 결과를 렌더링하기 위한 데이터 표현.
+ */
+data class NotificationLogItem(
+    val key: String,
+    val packageName: String,
+    val room: String?,
+    val sender: String?,
+    val body: String?,
+    val postedAt: Long
+)

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationParser.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationParser.kt
@@ -1,0 +1,39 @@
+package com.chimubot.maker.core.notif
+
+import android.app.Notification
+import android.service.notification.StatusBarNotification
+import android.os.Bundle
+import androidx.core.app.NotificationCompat
+import com.chimubot.maker.core.rules.CapturedNotification
+
+object NotificationParser {
+    fun parse(sbn: StatusBarNotification): CapturedNotification? {
+        val notification = sbn.notification
+        val replyHandle = ReplyActionFinder.find(notification)
+        val extras = notification.extras
+        val title = extras?.getCharSequence(Notification.EXTRA_TITLE)?.toString()
+        val conversationTitle = extras?.getCharSequence(Notification.EXTRA_CONVERSATION_TITLE)?.toString()
+        val text = extras?.getCharSequence(Notification.EXTRA_TEXT)?.toString()
+        val isGroupConversation = extras?.getBoolean(NotificationCompat.EXTRA_IS_GROUP_CONVERSATION) ?: false
+        val (resolvedText, resolvedSender) = resolveLatestMessage(extras)
+
+        return CapturedNotification(
+            key = sbn.key,
+            packageName = sbn.packageName,
+            postedAt = sbn.postTime,
+            room = conversationTitle ?: title,
+            sender = resolvedSender,
+            text = resolvedText ?: text,
+            isGroup = isGroupConversation,
+            replyHandle = replyHandle
+        )
+    }
+
+    private fun resolveLatestMessage(extras: Bundle?): Pair<String?, String?> {
+        val messages = extras?.getParcelableArray(NotificationCompat.EXTRA_MESSAGES) ?: return null to null
+        val last = messages.lastOrNull() as? Bundle ?: return null to null
+        val body = last.getCharSequence(NotificationCompat.EXTRA_TEXT)?.toString()
+        val sender = last.getCharSequence(NotificationCompat.EXTRA_SENDER)?.toString()
+        return body to sender
+    }
+}

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationServiceInitializer.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationServiceInitializer.kt
@@ -1,0 +1,30 @@
+package com.chimubot.maker.core.notif
+
+import android.content.Context
+import com.chimubot.maker.core.dispatch.ReplyDispatcher
+import com.chimubot.maker.core.rules.RuleEngineRegistry
+import com.chimubot.maker.core.rules.SimpleLoggingRuleEngine
+
+object NotificationServiceInitializer {
+    @Volatile
+    private var initialized = false
+    private var dispatcher: ReplyDispatcher? = null
+
+    fun ensure(context: Context) {
+        if (!initialized) {
+            synchronized(this) {
+                if (!initialized) {
+                    val createdDispatcher = ReplyDispatcher(context)
+                    dispatcher = createdDispatcher
+                    NotificationTargetRegistry.install(KakaoTalkOnlyFilter)
+                    RuleEngineRegistry.install(SimpleLoggingRuleEngine(createdDispatcher))
+                    initialized = true
+                }
+            }
+        }
+    }
+
+    fun dispatcher(): ReplyDispatcher {
+        return dispatcher ?: error("ReplyDispatcher not initialized")
+    }
+}

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationServiceInitializer.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationServiceInitializer.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.chimubot.maker.core.dispatch.ReplyDispatcher
 import com.chimubot.maker.core.rules.RuleEngineRegistry
 import com.chimubot.maker.core.rules.SimpleLoggingRuleEngine
+import com.chimubot.maker.core.state.ReplyHandleCache
+import com.chimubot.maker.core.state.ReplySendTelemetry
 
 object NotificationServiceInitializer {
     @Volatile
@@ -14,7 +16,11 @@ object NotificationServiceInitializer {
         if (!initialized) {
             synchronized(this) {
                 if (!initialized) {
-                    val createdDispatcher = ReplyDispatcher(context)
+                    val createdDispatcher = ReplyDispatcher(
+                        context = context,
+                        handleProvider = ReplyHandleCache,
+                        observer = ReplySendTelemetry
+                    )
                     dispatcher = createdDispatcher
                     NotificationTargetRegistry.install(KakaoTalkOnlyFilter)
                     RuleEngineRegistry.install(SimpleLoggingRuleEngine(createdDispatcher))

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationTargetFilter.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/NotificationTargetFilter.kt
@@ -1,0 +1,26 @@
+package com.chimubot.maker.core.notif
+
+interface NotificationTargetFilter {
+    fun shouldProcess(packageName: String): Boolean
+}
+
+object AllowAllTargetFilter : NotificationTargetFilter {
+    override fun shouldProcess(packageName: String): Boolean = true
+}
+
+object KakaoTalkOnlyFilter : NotificationTargetFilter {
+    override fun shouldProcess(packageName: String): Boolean = packageName == KAKAO_TALK_PACKAGE
+
+    private const val KAKAO_TALK_PACKAGE = "com.kakao.talk"
+}
+
+object NotificationTargetRegistry {
+    @Volatile
+    private var delegate: NotificationTargetFilter = AllowAllTargetFilter
+
+    fun install(filter: NotificationTargetFilter) {
+        delegate = filter
+    }
+
+    fun current(): NotificationTargetFilter = delegate
+}

--- a/core/notif/src/main/java/com/chimubot/maker/core/notif/ReplyActionFinder.kt
+++ b/core/notif/src/main/java/com/chimubot/maker/core/notif/ReplyActionFinder.kt
@@ -1,0 +1,23 @@
+package com.chimubot.maker.core.notif
+
+import android.app.Notification
+import com.chimubot.maker.core.dispatch.ReplyHandle
+
+object ReplyActionFinder {
+    fun find(notification: Notification): ReplyHandle? {
+        val actions = notification.actions ?: return null
+        for (action in actions) {
+            val remoteInputs = action.remoteInputs
+            if (remoteInputs != null && remoteInputs.isNotEmpty()) {
+                return ReplyHandle(
+                    pendingIntent = action.actionIntent,
+                    remoteInputs = remoteInputs,
+                    ttlMs = DEFAULT_TTL_MS
+                )
+            }
+        }
+        return null
+    }
+
+    private const val DEFAULT_TTL_MS = 60_000L
+}

--- a/core/rules/build.gradle.kts
+++ b/core/rules/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.chimubot.maker.core.rules"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(project(":core:dispatch"))
+    implementation("androidx.core:core-ktx:1.12.0")
+}

--- a/core/rules/src/main/AndroidManifest.xml
+++ b/core/rules/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.chimubot.maker.core.rules" />

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/CapturedNotification.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/CapturedNotification.kt
@@ -1,0 +1,17 @@
+package com.chimubot.maker.core.rules
+
+import com.chimubot.maker.core.dispatch.ReplyHandle
+
+/**
+ * NotificationListenerService에서 추출한 알림 정보의 표준 표현.
+ */
+data class CapturedNotification(
+    val key: String,
+    val packageName: String,
+    val postedAt: Long,
+    val room: String?,
+    val sender: String?,
+    val text: String?,
+    val isGroup: Boolean,
+    val replyHandle: ReplyHandle?
+)

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/OutgoingMessage.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/OutgoingMessage.kt
@@ -1,0 +1,11 @@
+package com.chimubot.maker.core.rules
+
+/**
+ * 규칙 매칭 결과로 Reply 큐에 들어가는 메시지 페이로드.
+ */
+data class OutgoingMessage(
+    val notificationKey: String,
+    val text: String,
+    val attempt: Int = 0,
+    val scheduledAt: Long = System.currentTimeMillis()
+)

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/OutgoingMessage.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/OutgoingMessage.kt
@@ -6,6 +6,7 @@ package com.chimubot.maker.core.rules
 data class OutgoingMessage(
     val notificationKey: String,
     val text: String,
+    val room: String? = null,
     val attempt: Int = 0,
     val scheduledAt: Long = System.currentTimeMillis()
 )

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/RuleEngine.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/RuleEngine.kt
@@ -1,0 +1,27 @@
+package com.chimubot.maker.core.rules
+
+/**
+ * 규칙 매칭과 전송 요청을 연결하는 최소 엔진 인터페이스.
+ */
+interface RuleEngine {
+    fun onIncoming(notification: CapturedNotification)
+}
+
+object NoopRuleEngine : RuleEngine {
+    override fun onIncoming(notification: CapturedNotification) = Unit
+}
+
+/**
+ * NotificationListenerService에서 사용할 전역 엔진 레지스트리.
+ * 앱 실행 시 실제 구현을 주입하고, 미초기화 상태에서는 Noop 엔진으로 동작한다.
+ */
+object RuleEngineRegistry {
+    @Volatile
+    private var delegate: RuleEngine = NoopRuleEngine
+
+    fun install(engine: RuleEngine) {
+        delegate = engine
+    }
+
+    fun current(): RuleEngine = delegate
+}

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/SimpleLoggingRuleEngine.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/SimpleLoggingRuleEngine.kt
@@ -25,7 +25,8 @@ class SimpleLoggingRuleEngine(
         dispatcher.enqueue(
             OutgoingMessage(
                 notificationKey = notification.key,
-                text = "[자동응답] ${triggerKeyword} 감지"
+                text = "[자동응답] ${triggerKeyword} 감지",
+                room = notification.room
             ),
             notification.replyHandle
         )

--- a/core/rules/src/main/java/com/chimubot/maker/core/rules/SimpleLoggingRuleEngine.kt
+++ b/core/rules/src/main/java/com/chimubot/maker/core/rules/SimpleLoggingRuleEngine.kt
@@ -1,0 +1,37 @@
+package com.chimubot.maker.core.rules
+
+import android.util.Log
+import com.chimubot.maker.core.dispatch.ReplyDispatcher
+import com.chimubot.maker.core.notif.CapturedNotification
+
+/**
+ * 1단계 프로토타입: 카카오톡 알림 본문에 고정 키워드가 포함되면 자동으로 응답을 큐에 넣는다.
+ */
+class SimpleLoggingRuleEngine(
+    private val dispatcher: ReplyDispatcher,
+    private val triggerKeyword: String = "자동응답"
+) : RuleEngine {
+
+    override fun onIncoming(notification: CapturedNotification) {
+        if (notification.replyHandle == null) {
+            Log.d(TAG, "Reply handle missing: ${notification.key}")
+            return
+        }
+        val body = notification.text.orEmpty()
+        if (!body.contains(triggerKeyword)) {
+            Log.d(TAG, "No trigger keyword in ${notification.key}")
+            return
+        }
+        dispatcher.enqueue(
+            OutgoingMessage(
+                notificationKey = notification.key,
+                text = "[자동응답] ${triggerKeyword} 감지"
+            ),
+            notification.replyHandle
+        )
+    }
+
+    companion object {
+        private const val TAG = "SimpleRuleEngine"
+    }
+}

--- a/core/state/build.gradle.kts
+++ b/core/state/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace = "com.chimubot.maker.core.notif"
+    namespace = "com.chimubot.maker.core.state"
     compileSdk = 34
 
     defaultConfig {
@@ -23,8 +23,6 @@ android {
 
 dependencies {
     implementation(project(":core:dispatch"))
-    implementation(project(":core:rules"))
-    implementation(project(":core:state"))
     implementation("androidx.core:core-ktx:1.12.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }

--- a/core/state/src/main/AndroidManifest.xml
+++ b/core/state/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.chimubot.maker.core.state" />

--- a/core/state/src/main/java/com/chimubot/maker/core/state/ReplyHandleCache.kt
+++ b/core/state/src/main/java/com/chimubot/maker/core/state/ReplyHandleCache.kt
@@ -1,0 +1,119 @@
+package com.chimubot.maker.core.state
+
+import android.os.SystemClock
+import com.chimubot.maker.core.dispatch.ReplyHandle
+import com.chimubot.maker.core.dispatch.ReplyHandleProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Reply PendingIntent를 메모리에 유지해 동일 알림 또는 동일 대화방에서 재사용할 수 있도록 한다.
+ * NotificationListener에서 새로운 알림이 도착할 때마다 갱신되며 TTL이 지나면 자동으로 제거된다.
+ */
+object ReplyHandleCache : ReplyHandleProvider {
+
+    private data class CacheEntry(
+        val handle: ReplyHandle,
+        val room: String?,
+        val expiresAtElapsed: Long
+    )
+
+    private val lock = Any()
+    private val entriesByKey = mutableMapOf<String, CacheEntry>()
+    private val _metrics = MutableStateFlow(ReplyHandleMetrics())
+    val metrics: StateFlow<ReplyHandleMetrics> = _metrics.asStateFlow()
+
+    override fun currentHandleFor(notificationKey: String, room: String?): ReplyHandle? {
+        val now = SystemClock.elapsedRealtime()
+        synchronized(lock) {
+            val changed = pruneExpiredLocked(now)
+            if (changed) {
+                publishMetricsLocked()
+            }
+            entriesByKey[notificationKey]?.let { entry ->
+                if (entry.expiresAtElapsed > now) {
+                    return entry.handle
+                }
+            }
+            if (room != null) {
+                entriesByKey.values.firstOrNull { entry ->
+                    entry.room == room && entry.expiresAtElapsed > now
+                }?.let { return it.handle }
+            }
+        }
+        return null
+    }
+
+    override fun invalidate(notificationKey: String) {
+        synchronized(lock) {
+            val removed = entriesByKey.remove(notificationKey)
+            if (removed != null) {
+                publishMetricsLocked()
+            }
+        }
+    }
+
+    fun upsert(notificationKey: String, room: String?, handle: ReplyHandle) {
+        val expiresAt = SystemClock.elapsedRealtime() + handle.ttlMs
+        synchronized(lock) {
+            val changed = pruneExpiredLocked(SystemClock.elapsedRealtime())
+            if (room != null) {
+                val iterator = entriesByKey.entries.iterator()
+                while (iterator.hasNext()) {
+                    val entry = iterator.next()
+                    if (entry.value.room == room) {
+                        iterator.remove()
+                    }
+                }
+            }
+            entriesByKey[notificationKey] = CacheEntry(handle, room, expiresAt)
+            if (changed) {
+                publishMetricsLocked()
+            }
+            publishMetricsLocked()
+        }
+    }
+
+    fun pruneExpired() {
+        synchronized(lock) {
+            val changed = pruneExpiredLocked(SystemClock.elapsedRealtime())
+            if (changed) {
+                publishMetricsLocked()
+            }
+        }
+    }
+
+    private fun pruneExpiredLocked(now: Long): Boolean {
+        var changed = false
+        val iterator = entriesByKey.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value.expiresAtElapsed <= now) {
+                iterator.remove()
+                changed = true
+            }
+        }
+        return changed
+    }
+
+    private fun publishMetricsLocked() {
+        val activeCount = entriesByKey.size
+        val timestamp = System.currentTimeMillis()
+        _metrics.update {
+            it.copy(
+                activeCount = activeCount,
+                lastUpdatedAt = timestamp
+            )
+        }
+    }
+}
+
+/**
+ * Reply 핸들 캐시 현황.
+ */
+data class ReplyHandleMetrics(
+    val activeCount: Int = 0,
+    val lastUpdatedAt: Long = System.currentTimeMillis()
+)

--- a/core/state/src/main/java/com/chimubot/maker/core/state/ReplySendTelemetry.kt
+++ b/core/state/src/main/java/com/chimubot/maker/core/state/ReplySendTelemetry.kt
@@ -1,0 +1,63 @@
+package com.chimubot.maker.core.state
+
+import com.chimubot.maker.core.dispatch.ReplySendObserver
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Reply 전송 성공/실패/재시도 이력을 추적해 UI에서 시각화할 수 있도록 한다.
+ */
+object ReplySendTelemetry : ReplySendObserver {
+
+    private val _metrics = MutableStateFlow(ReplySendMetrics())
+    val metrics: StateFlow<ReplySendMetrics> = _metrics.asStateFlow()
+
+    override fun onSuccess() {
+        val now = System.currentTimeMillis()
+        _metrics.update {
+            it.copy(
+                successCount = it.successCount + 1,
+                lastUpdatedAt = now
+            )
+        }
+    }
+
+    override fun onFailure(error: Throwable) {
+        val now = System.currentTimeMillis()
+        val message = error.message ?: error::class.java.simpleName
+        _metrics.update {
+            it.copy(
+                failureCount = it.failureCount + 1,
+                lastErrorMessage = message,
+                lastFailureAt = now,
+                lastUpdatedAt = now
+            )
+        }
+    }
+
+    override fun onRetryScheduled(attempt: Int) {
+        val now = System.currentTimeMillis()
+        _metrics.update {
+            it.copy(
+                retryCount = it.retryCount + 1,
+                lastRetryAttempt = attempt,
+                lastUpdatedAt = now
+            )
+        }
+    }
+}
+
+/**
+ * Reply 전송 상태 요약.
+ */
+data class ReplySendMetrics(
+    val successCount: Long = 0,
+    val failureCount: Long = 0,
+    val retryCount: Long = 0,
+    val lastErrorMessage: String? = null,
+    val lastFailureAt: Long? = null,
+    val lastRetryAttempt: Int = 0,
+    val lastUpdatedAt: Long = System.currentTimeMillis()
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dkotlin.daemon.heap.size=1g
+android.useAndroidX=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -e
+APP_HOME="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_JVM_OPTS="-Xmx64m -Xms64m"
+CLASSPATH="$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
+CLASSPATH="$CLASSPATH:$APP_HOME/gradle/wrapper/gradle-wrapper-shared-8.5.jar"
+CLASSPATH="$CLASSPATH:$APP_HOME/gradle/wrapper/gradle-cli-8.5.jar"
+CLASSPATH="$CLASSPATH:$APP_HOME/gradle/wrapper/gradle-base-annotations-8.5.jar"
+CLASSPATH="$CLASSPATH:$APP_HOME/gradle/wrapper/gradle-files-8.5.jar"
+CLASSPATH="$CLASSPATH:$APP_HOME/gradle/wrapper/gradle-functional-8.5.jar"
+
+if [ -n "$JAVA_HOME" ]; then
+  JAVA_EXE="$JAVA_HOME/bin/java"
+  if [ ! -x "$JAVA_EXE" ]; then
+    echo "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME" >&2
+    exit 1
+  fi
+else
+  JAVA_EXE="java"
+fi
+
+exec "$JAVA_EXE" $DEFAULT_JVM_OPTS -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,16 @@
+@echo off
+set APP_HOME=%~dp0
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+set CLASSPATH=%CLASSPATH%;%APP_HOME%\gradle\wrapper\gradle-wrapper-shared-8.5.jar
+set CLASSPATH=%CLASSPATH%;%APP_HOME%\gradle\wrapper\gradle-cli-8.5.jar
+set CLASSPATH=%CLASSPATH%;%APP_HOME%\gradle\wrapper\gradle-base-annotations-8.5.jar
+set CLASSPATH=%CLASSPATH%;%APP_HOME%\gradle\wrapper\gradle-files-8.5.jar
+set CLASSPATH=%CLASSPATH%;%APP_HOME%\gradle\wrapper\gradle-functional-8.5.jar
+set DEFAULT_JVM_OPTS=-Xmx64m -Xms64m
+if not defined JAVA_HOME goto findJavaFromPath
+set JAVA_EXE=%JAVA_HOME%\bin\java.exe
+if exist "%JAVA_EXE%" goto init
+:findJavaFromPath
+set JAVA_EXE=java.exe
+:init
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,5 +4,6 @@ include(
     ":app",
     ":core:notif",
     ":core:dispatch",
-    ":core:rules"
+    ":core:rules",
+    ":core:state"
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,8 @@
+rootProject.name = "ChimuBot-Maker"
+
+include(
+    ":app",
+    ":core:notif",
+    ":core:dispatch",
+    ":core:rules"
+)


### PR DESCRIPTION
## Summary
- 루트 불필요 알림→규칙 매칭→Reply PendingIntent 재사용 파이프라인을 유지한 채, 카카오톡 알림 파싱 결과를 시각화하는 `NotificationLogActivity`를 추가했습니다.
- `NotificationLogRepository`로 최근 알림의 룸/보낸이/본문 정보를 수집해 UI에서 확인할 수 있도록 했습니다.
- UI 표시를 위해 AndroidX Activity·Lifecycle·RecyclerView 의존성을 연결하고 README에 경량 로그 화면 도입을 반영했습니다.

## Testing
- `./gradlew help` *(실패: 저장소 정책상 Gradle wrapper JAR 미포함)*

------
https://chatgpt.com/codex/tasks/task_e_68e3067546588322b6ebd4fa02137630